### PR TITLE
Add Makefile and path to build binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,52 @@
+export SHELL := /bin/bash
+
+CARTHAGE_DIR:=Carthage
+BUILD_DIR:=build
+
+# PHONY (non-file) Targets
+# ------------------------
+.PHONY: build clean help
+
+# Common targets
+# --------------
+build: carthage app  ## Build everything
+
+clean: ## Clean up make artifacts
+	rm -rf $(BUILD_DIR)
+
+
+# Carthage dependencies
+# ---------------------
+carthage: $(CARTHAGE_DIR)/.make ## Install or update carthage dependencies
+
+$(CARTHAGE_DIR)/.make: Cartfile
+	carthage update --platform mac
+	touch $@
+
+
+# Building Markoff.app with `xcodebuild`
+# --------------------------------------
+app: carthage $(BUILD_DIR)/Markoff.app
+
+$(BUILD_DIR)/Markoff.app:
+	xcodebuild build
+	mv $(BUILD_DIR)/Release/Markoff.app $(BUILD_DIR)/Markoff.app
+
+
+# Building Markoff.app DMG for release
+# ------------------------------------
+dmg: build $(BUILD_DIR)/Markoff.dmg
+
+$(BUILD_DIR)/Markoff.dmg:
+	mkdir -p $(BUILD_DIR)/tmp/
+	cp -r $(BUILD_DIR)/Markoff.app $(BUILD_DIR)/tmp/
+	cd $(BUILD_DIR)/tmp/ && hdiutil create -srcfolder . -volname Markoff ../Markoff.dmg
+	rm -r $(BUILD_DIR)/tmp/
+
+
+
+
+# `make help` -  see http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+# ------------------------------------------------------------------------------------
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/README.md
+++ b/README.md
@@ -25,6 +25,20 @@ Make sure you have [Carthage] installed, then run in the project root:
 carthage update --platform mac
 ~~~
 
+## Building Binaries for Distribution
+
+To build a .app bundle:
+
+~~~shell
+make app
+~~~
+
+To build a .dmg image:
+
+~~~shell
+make dmg
+~~~
+
 ## License
 
 See LICENSE file.


### PR DESCRIPTION
This Makefile should make it easy for a developer to generate
distributions that can be hosted on a platform other than the Mac App
Store.
- `make build` (or `make` without options) will compile the application
- `make dmg` will generate a DMG file for distribution

All binaries are placed in the `build/` directory.

Hopefully this can help address https://github.com/thoughtbot/Markoff/issues/16 and subsequently https://github.com/thoughtbot/Markoff/issues/12 -- which is why I went down this rabbit hole in the first place 😆 
